### PR TITLE
Logger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ ignore = [
     "D105",     # Missing docstring in magic method
     "D107",     # Missing docstring in init
     "D203",     # 1 blank line required before class docstring (found 0)
-    "D213",     # Multiline docstring summary should start at the second line
+    "D212",     # Multiline docstring summary should start at the second line
     "EM101",    # Missing exception type in 'except'
     "EM103",    # Exception name should be lowercase
     "FA100",    # Incorrect use of assert statement

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,0 +1,29 @@
+import logging
+import sys
+from logging.handlers import RotatingFileHandler
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+formatter_stdout = logging.Formatter(
+    "%(asctime)s | [%(filename)s:%(lineno)d] | %(levelname)s | %(message)s", "%d-%m-%Y %H:%M:%S"
+)
+formatter_file = logging.Formatter(
+    "%(asctime)s | [%(pathname)s:%(lineno)d] | %(levelname)s | %(message)s", "%d-%m-%Y %H:%M:%S"
+)
+
+stdout_handler = logging.StreamHandler(sys.stdout)
+stdout_handler.setLevel(level=logging.DEBUG)
+stdout_handler.setFormatter(fmt=formatter_stdout)
+
+file_handler = RotatingFileHandler(
+    filename="logs.log",
+    mode="a",
+    maxBytes=1e6,
+    backupCount=0,
+    encoding="UTF-8",
+)
+file_handler.setLevel(level=logging.DEBUG)
+file_handler.setFormatter(fmt=formatter_file)
+
+logger.addHandler(file_handler)
+logger.addHandler(stdout_handler)

--- a/src/logger.py
+++ b/src/logger.py
@@ -4,16 +4,13 @@ from logging.handlers import RotatingFileHandler
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-formatter_stdout = logging.Formatter(
+formatter = logging.Formatter(
     "%(asctime)s | [%(filename)s:%(lineno)d] | %(levelname)s | %(message)s", "%d-%m-%Y %H:%M:%S"
-)
-formatter_file = logging.Formatter(
-    "%(asctime)s | [%(pathname)s:%(lineno)d] | %(levelname)s | %(message)s", "%d-%m-%Y %H:%M:%S"
 )
 
 stdout_handler = logging.StreamHandler(sys.stdout)
 stdout_handler.setLevel(level=logging.DEBUG)
-stdout_handler.setFormatter(fmt=formatter_stdout)
+stdout_handler.setFormatter(fmt=formatter)
 
 file_handler = RotatingFileHandler(
     filename="logs.log",
@@ -23,7 +20,7 @@ file_handler = RotatingFileHandler(
     encoding="UTF-8",
 )
 file_handler.setLevel(level=logging.DEBUG)
-file_handler.setFormatter(fmt=formatter_file)
+file_handler.setFormatter(fmt=formatter)
 
 logger.addHandler(file_handler)
 logger.addHandler(stdout_handler)

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,11 @@
+from logger import logger
+
+
+def main():
+    """The main function."""
+    logger.info("Calculate finished")
+    return 0
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added logger to display logs in a terminal and store them in a `loggs.log` file.  The maximum of file is 1MB.

Example of log: 
`dd-mm-yyyy HH:MM:SS | [file_path:log_line] | level_name | message`